### PR TITLE
 SwiPICs updated to support SWI-Prolog Version 8.0.3-1 32bit and 64bit

### DIFF
--- a/CalcStreamSize/CalcStreamSize.vcxproj
+++ b/CalcStreamSize/CalcStreamSize.vcxproj
@@ -42,6 +42,7 @@
     <SccLocalPath>.</SccLocalPath>
     <SccProvider>{4CA58AB2-18FA-4F8D-95D4-32DDF27D184C}</SccProvider>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
@@ -83,7 +84,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -206,7 +207,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SWI_HOME_DIR)\lib\libswipl.dll.a;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(SWI_HOME_DIR)\bin\libswipl.dll.a%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>

--- a/HelloWorldDemoFs/HelloWorldDemoFs.fsproj
+++ b/HelloWorldDemoFs/HelloWorldDemoFs.fsproj
@@ -16,6 +16,7 @@
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,8 +40,10 @@
     <DocumentationFile>bin\Release\HelloWorldDemoFs.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -130,9 +133,19 @@
     <OutputPath>bin\Debug64\</OutputPath>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets" Condition="(!Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')) And (Exists('$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets'))" />
-  <Import Project="$(MSBuildExtensionsPath32)\FSharp\1.0\Microsoft.FSharp.Targets" Condition="(!Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')) And (!Exists('$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets')) And (Exists('$(MSBuildExtensionsPath32)\FSharp\1.0\Microsoft.FSharp.Targets'))" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 	     Other similar extension points exist, see Microsoft.Common.targets.
 	<Target Name="BeforeBuild">

--- a/README
+++ b/README
@@ -1,4 +1,10 @@
-﻿
+WHAT'S NEW
+==========
+ 
+ - SwiPICs updated to support SWI-Prolog Version 8.0.3-1 32bit and 64bit
+
+------------------------------------------------------------------------------
+
 			An interface from .Net languages to SWI-Prolog
 
 This library is a .Net (CSharp) interface to SWI-Prolog. The described  

--- a/SwiPlCs/LibPl.cs
+++ b/SwiPlCs/LibPl.cs
@@ -142,12 +142,12 @@ namespace SbsSW.SwiPlCs
             // to calculate to following values use the C++ Project CalcStreamSize
 #if _PL_X64
 #warning _PL_X64 is defined
-            const int sizeOfIostream = 232;
+            const int sizeOfIostream = 256;
             const int offsetToPoninterOfIofunctions = 104;
             const int sizeOfPointer = 8;
 #else
 #warning _PL_X64 is NOT defined
-            const int sizeOfIostream = 144;
+            const int sizeOfIostream = 160;
             const int offsetToPoninterOfIofunctions = 72;
             const int sizeOfPointer = 4;
 #endif

--- a/SwiPlCs_git.sln
+++ b/SwiPlCs_git.sln
@@ -1,16 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CalcStreamSize", "CalcStreamSize\CalcStreamSize.vcxproj", "{6F6C0629-2AEC-48FC-BF78-8E6B30ABF741}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SwiPLcs", "SwiPlCs\SwiPLcs.csproj", "{60B9C0D5-B0BB-452D-832F-12DED90CCD67}"
-EndProject
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2026
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{06044D84-EEB0-4620-918D-27578BCD0AF8}"
 	ProjectSection(SolutionItems) = preProject
 		CustomDictionary.xml = CustomDictionary.xml
 		README = README
 		SWI-cs.FxCop = SWI-cs.FxCop
 	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CalcStreamSize", "CalcStreamSize\CalcStreamSize.vcxproj", "{6F6C0629-2AEC-48FC-BF78-8E6B30ABF741}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SwiPLcs", "SwiPlCs\SwiPLcs.csproj", "{60B9C0D5-B0BB-452D-832F-12DED90CCD67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSwiPl", "TestSwiPl\TestSwiPl.csproj", "{66F7CD01-3283-4DAD-A961-CB4D906C352B}"
 EndProject
@@ -242,5 +244,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {72A0FE71-C193-4C88-8157-6C35E34D3FAA}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Updated sizeOfIostream in LibPI.cs to support libswipl.dll from SWI-Prolog Version 8.0.3

# Version 64Bit
const int sizeOfIostream = 256;

# Version 32Bit
const int sizeOfIostream = 160;